### PR TITLE
Fix Old DB column name

### DIFF
--- a/api.js
+++ b/api.js
@@ -78,7 +78,7 @@ const getUserResponse = (username, coinstac = false) => {
         .add(1, username === 'password-will-expire' ? 'day' : 'year')
         .format(),
       passwordResetExpiration: null, // TODO: populate
-      passwordResetKey: null,
+      passwordResetHash: null,
       passwordResetSessionId: null, // TODO: populate
       siteId: '7',
       username


### PR DESCRIPTION
# Problem
The database column for reset keys has changed to hashes, fix it.